### PR TITLE
Fix bug with fallback data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = () => all().then(d => d.shift());
+module.exports = () => all().then(d => d[0]);
 module.exports.all = all;
 module.exports.cycle = cycle;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-user-agent",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "get a real user-agent string sourced from top 10 current",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This issue did not happen with live data. Subsequent calls to all() with fallback data shifted the data. In other words, by the 10th call, all fallback data would have been shifted off resulting in an empty array. 

Simple fix is to use first index instead of shift, to avoid modifying data